### PR TITLE
Update latent_sampling.py

### DIFF
--- a/software/deep_boltzmann/sampling/latent_sampling.py
+++ b/software/deep_boltzmann/sampling/latent_sampling.py
@@ -1,7 +1,14 @@
 __author__ = 'noe'
 
 from deep_boltzmann.util import ensure_traj
-from scipy.misc import logsumexp
+
+# Newer version of SciPy changes location of logsumexp. Keep backward compatibility.
+import scipy.misc
+if hasattr(scipy.misc, 'logsumexp'):
+    from scipy.misc import logsumexp
+else:
+    from scipy.special import logsumexp
+    
 import numpy as np
 import keras
 


### PR DESCRIPTION
Newer version of SciPy changes location of logsumexp from scipy.misc to scipy.special. Keep backward compatibility.